### PR TITLE
변환 완료된 파일 더블클릭으로 열기

### DIFF
--- a/PdfToOfficeApp/MainWindow.xaml
+++ b/PdfToOfficeApp/MainWindow.xaml
@@ -8,7 +8,9 @@
         Title="{DynamicResource IDS_APP_NAME}"
         Background="{DynamicResource bg}"
         Height="450"
-        Width="800">
+        Width="800"
+        MinHeight="380"
+        MinWidth="420">
 
   <Window.DataContext>
     <Binding Source="{StaticResource main-vm}" />

--- a/PdfToOfficeApp/MainWindow.xaml.cs
+++ b/PdfToOfficeApp/MainWindow.xaml.cs
@@ -222,10 +222,12 @@ namespace PdfToOfficeApp
                     pdfToOffice.SetUserDir(model.UserDir);
 
                     doc.ResCode = pdfToOffice.Convert(doc.FilePath, doc.Password);
+                    doc.OutPath = pdfToOffice.SetOutPath();
 
                     if (doc.ResCode == RES_CODE.Success)
                     {
                         doc.ConvStatus = CONV_STATUS.COMPLETED;
+                        doc.Tooltip = doc.OutPath;
                     }
                     else if (doc.ResCode == RES_CODE.Canceled || doc.ResCode == RES_CODE.CanceledExists)
                     {

--- a/PdfToOfficeApp/MainWindow.xaml.cs
+++ b/PdfToOfficeApp/MainWindow.xaml.cs
@@ -222,7 +222,7 @@ namespace PdfToOfficeApp
                     pdfToOffice.SetUserDir(model.UserDir);
 
                     doc.ResCode = pdfToOffice.Convert(doc.FilePath, doc.Password);
-                    doc.OutPath = pdfToOffice.SetOutPath();
+                    doc.OutPath = pdfToOffice.GetOutPath();
 
                     if (doc.ResCode == RES_CODE.Success)
                     {

--- a/PdfToOfficeApp/View/DocListBox.cs
+++ b/PdfToOfficeApp/View/DocListBox.cs
@@ -49,50 +49,17 @@ namespace PdfToOfficeApp
         {
             if (GetModel().AppStatus == APP_STATUS.COMPLETED)
             {
-                // TODO : 출력 파일 경로 및 파일명 -> 출력될 파일 명명한 부분 찾아서 바꾸기
-                System.Diagnostics.Process process = new System.Diagnostics.Process();
-                DocListBox temp = (DocListBox)e.Source;
-                DocList docList = (DocList)temp.ItemsSource;
-                Doc doc = docList[0];
-                string strFileName = doc.FileName;
-                string strFilePath = doc.FilePath;
-                strFilePath = strFilePath.Replace(strFileName, "");
-                strFileName = strFileName.Replace(".pdf", "");
-                string strFileType;
-                switch (GetModel().ConvFileType)
+                var process = new System.Diagnostics.Process();
+                Doc doc = (Doc)this.SelectedItem;
+
+                try
                 {
-                    case FILE_TYPE.DOCX:
-                        strFileType = ".docx";
-                        break;
-                    case FILE_TYPE.PPTX:
-                        strFileType = ".pptx";
-                        break;
-                    case FILE_TYPE.XLSX:
-                        strFileType = ".xlsx";
-                        break;
-                    case FILE_TYPE.IMAGE:
-                        strFileType = ".image";
-                        break;
-                    default:
-                        strFileType = ".docx";
-                        break;
-                }
-
-                strFileName += strFileType;
-
-                if (GetModel().IsSaveToUserDir)
-                    strFilePath = GetModel().UserDir + "\\" + strFileName;
-                else
-                    strFilePath += strFileName;
-
-                try//if (File.Exists(strFilePath))
-                {
-                    process.StartInfo.FileName = strFilePath;
+                    process.StartInfo.FileName = doc.OutPath;
                     process.Start();
                 }
-                catch
+                catch (Exception ex)
                 {
-
+                    Console.WriteLine(ex.Message);
                 }
             }
         }

--- a/PdfToOfficeApp/View/DocListBox.cs
+++ b/PdfToOfficeApp/View/DocListBox.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.IO;
 using System.Windows.Controls;
+using System.Windows.Input;
+using PdfToOfficeAppModule;
 
 namespace PdfToOfficeApp
 {
@@ -39,6 +42,58 @@ namespace PdfToOfficeApp
             else
             {
                 GetModel().AppStatus = APP_STATUS.INIT;
+            }
+        }
+
+        protected override void OnMouseDoubleClick(MouseButtonEventArgs e)
+        {
+            if (GetModel().AppStatus == APP_STATUS.COMPLETED)
+            {
+                // TODO : 출력 파일 경로 및 파일명 -> 출력될 파일 명명한 부분 찾아서 바꾸기
+                System.Diagnostics.Process process = new System.Diagnostics.Process();
+                DocListBox temp = (DocListBox)e.Source;
+                DocList docList = (DocList)temp.ItemsSource;
+                Doc doc = docList[0];
+                string strFileName = doc.FileName;
+                string strFilePath = doc.FilePath;
+                strFilePath = strFilePath.Replace(strFileName, "");
+                strFileName = strFileName.Replace(".pdf", "");
+                string strFileType;
+                switch (GetModel().ConvFileType)
+                {
+                    case FILE_TYPE.DOCX:
+                        strFileType = ".docx";
+                        break;
+                    case FILE_TYPE.PPTX:
+                        strFileType = ".pptx";
+                        break;
+                    case FILE_TYPE.XLSX:
+                        strFileType = ".xlsx";
+                        break;
+                    case FILE_TYPE.IMAGE:
+                        strFileType = ".image";
+                        break;
+                    default:
+                        strFileType = ".docx";
+                        break;
+                }
+
+                strFileName += strFileType;
+
+                if (GetModel().IsSaveToUserDir)
+                    strFilePath = GetModel().UserDir + "\\" + strFileName;
+                else
+                    strFilePath += strFileName;
+
+                try//if (File.Exists(strFilePath))
+                {
+                    process.StartInfo.FileName = strFilePath;
+                    process.Start();
+                }
+                catch
+                {
+
+                }
             }
         }
 

--- a/PdfToOfficeApp/View/DocListComp.xaml
+++ b/PdfToOfficeApp/View/DocListComp.xaml
@@ -218,7 +218,7 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
                 Value="Disabled" />
         <Setter Property="SelectionMode"
-                Value="Multiple" />
+                Value="Extended" />
         <Setter Property="AllowDrop"
                 Value="True" />
         <Setter Property="BorderThickness"

--- a/PdfToOfficeApp/ViewModel/Doc.cs
+++ b/PdfToOfficeApp/ViewModel/Doc.cs
@@ -101,5 +101,16 @@ namespace PdfToOfficeApp
                 OnPropertyChanged("ResCode");
             }
         }
+
+        private string _OutPath = string.Empty;
+        public string OutPath
+        {
+            get { return _OutPath; }
+            set
+            {
+                _OutPath = value;
+                OnPropertyChanged("OutPath");
+            }
+        }
     }
 }

--- a/PdfToOfficeAppModule/IPdfToOfficeProxy.h
+++ b/PdfToOfficeAppModule/IPdfToOfficeProxy.h
@@ -15,7 +15,7 @@ interface class IPdfToOfficeProxy {
   virtual void SetOverwrite(bool overwrite) = 0;
   virtual void SetSaveToUserDir(bool isSaveToUserDir) = 0;
   virtual void SetUserDir(System::String ^ path) = 0;
-  virtual System::String ^ SetOutPath() = 0;
+  virtual System::String ^ GetOutPath() = 0;
   virtual void SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli) = 0;
 };
 

--- a/PdfToOfficeAppModule/IPdfToOfficeProxy.h
+++ b/PdfToOfficeAppModule/IPdfToOfficeProxy.h
@@ -15,6 +15,7 @@ interface class IPdfToOfficeProxy {
   virtual void SetOverwrite(bool overwrite) = 0;
   virtual void SetSaveToUserDir(bool isSaveToUserDir) = 0;
   virtual void SetUserDir(System::String ^ path) = 0;
+  virtual System::String ^ SetOutPath() = 0;
   virtual void SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli) = 0;
 };
 

--- a/PdfToOfficeAppModule/PdfToOfficeProxy.cpp
+++ b/PdfToOfficeAppModule/PdfToOfficeProxy.cpp
@@ -66,11 +66,11 @@ void PdfToOfficeProxy::SetUserDir(System::String ^ path) {
   lib->SetUserDir(msclr::interop::marshal_as<HpdfToOffice::String>(path));
 }
 
-System::String ^ PdfToOfficeProxy::SetOutPath() {
+System::String ^ PdfToOfficeProxy::GetOutPath() {
   if (!lib) {
     return nullptr;
   }
-  return gcnew System::String(lib->SetOutPath().c_str());
+  return gcnew System::String(lib->GetOutPath().c_str());
 }
 
 void PdfToOfficeProxy::SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli) {

--- a/PdfToOfficeAppModule/PdfToOfficeProxy.cpp
+++ b/PdfToOfficeAppModule/PdfToOfficeProxy.cpp
@@ -66,6 +66,13 @@ void PdfToOfficeProxy::SetUserDir(System::String ^ path) {
   lib->SetUserDir(msclr::interop::marshal_as<HpdfToOffice::String>(path));
 }
 
+System::String ^ PdfToOfficeProxy::SetOutPath() {
+  if (!lib) {
+    return nullptr;
+  }
+  return gcnew System::String(lib->SetOutPath().c_str());
+}
+
 void PdfToOfficeProxy::SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli) {
   ProgressSiteProxy* progressSiteProxy = new ProgressSiteProxy(progressSiteCli);
   m_ProgressSite = static_cast<HpdfToOffice::IProgressSite*>(progressSiteProxy);

--- a/PdfToOfficeAppModule/PdfToOfficeProxy.h
+++ b/PdfToOfficeAppModule/PdfToOfficeProxy.h
@@ -21,7 +21,7 @@ ref class PdfToOfficeProxy : public IPdfToOfficeProxy {
   virtual void SetOverwrite(bool overwrite);
   virtual void SetSaveToUserDir(bool isSaveToUserDir);
   virtual void SetUserDir(System::String ^ path);
-  virtual System::String ^ SetOutPath();
+  virtual System::String ^ GetOutPath();
   virtual void SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli);
 
  protected:

--- a/PdfToOfficeAppModule/PdfToOfficeProxy.h
+++ b/PdfToOfficeAppModule/PdfToOfficeProxy.h
@@ -21,6 +21,7 @@ ref class PdfToOfficeProxy : public IPdfToOfficeProxy {
   virtual void SetOverwrite(bool overwrite);
   virtual void SetSaveToUserDir(bool isSaveToUserDir);
   virtual void SetUserDir(System::String ^ path);
+  virtual System::String ^ SetOutPath();
   virtual void SetProgressSiteCli(IProgressSiteCli ^ progressSiteCli);
 
  protected:

--- a/PdfToOfficeLib/IPdfToOffice.h
+++ b/PdfToOfficeLib/IPdfToOffice.h
@@ -12,7 +12,7 @@ class IPdfToOffice {
   virtual void SetOverwrite(bool overwrite) = 0;
   virtual void SetSaveToUserDir(bool saveToUserDir) = 0;
   virtual void SetUserDir(const String& path) = 0;
-  virtual String SetOutPath() = 0;
+  virtual String GetOutPath() = 0;
 };
 
 }  // namespace HpdfToOffice

--- a/PdfToOfficeLib/IPdfToOffice.h
+++ b/PdfToOfficeLib/IPdfToOffice.h
@@ -12,6 +12,7 @@ class IPdfToOffice {
   virtual void SetOverwrite(bool overwrite) = 0;
   virtual void SetSaveToUserDir(bool saveToUserDir) = 0;
   virtual void SetUserDir(const String& path) = 0;
+  virtual String SetOutPath() = 0;
 };
 
 }  // namespace HpdfToOffice

--- a/PdfToOfficeLib/PdfToDocx.cpp
+++ b/PdfToOfficeLib/PdfToDocx.cpp
@@ -13,7 +13,9 @@ RES_CODE PdfToDocx::Convert(const String& path, const String& password) {
     outPath = m_UserDir + L"\\" + Util::Path::GetFileName(outPath);
   }
   outPath = Util::Path::ChangeExt(outPath, L".docx");
-  outPath = Util::Path::GetAvailFileName(outPath);
+  if (!m_IsOverwrite)
+    outPath = Util::Path::GetAvailFileName(outPath);
+  m_OutPath = outPath;
 
   RES_CODE status = RES_CODE::Success;
   try {
@@ -33,7 +35,7 @@ RES_CODE PdfToDocx::Convert(const String& path, const String& password) {
     pConverter->SetReconstructionMode(
         SolidFramework::Converters::Plumbing::ReconstructionMode::Flowing);
 
-    pConverter->ConvertTo(outPath, true);
+    pConverter->ConvertTo(outPath, m_IsOverwrite);
 
     status = static_cast<RES_CODE>(pConverter->GetResults()[0]->GetStatus());
 

--- a/PdfToOfficeLib/PdfToImage.cpp
+++ b/PdfToOfficeLib/PdfToImage.cpp
@@ -11,6 +11,7 @@ RES_CODE PdfToImage::Convert(const String& path, const String& password) {
   } else {
     outDir = Util::Path::ChangeExt(path, L".image");
   }
+  m_OutPath = outDir;
 
   RES_CODE status = RES_CODE::Success;
   try {

--- a/PdfToOfficeLib/PdfToOffice.cpp
+++ b/PdfToOfficeLib/PdfToOffice.cpp
@@ -37,6 +37,35 @@ RES_CODE PdfToOffice::Init() {
   return RES_CODE::Success;
 }
 
+RES_CODE PdfToOffice::Convert(const String& /*path*/,
+                              const String& /*password*/) {
+  return RES_CODE::Unknown;
+}
+
+void PdfToOffice::Cancel() {
+  if (!m_Converter) {
+    return;
+  }
+  m_Converter->Cancel();
+  m_Converter->ClearSourceFiles();
+}
+
+void PdfToOffice::SetOverwrite(bool overwrite) {
+  m_IsOverwrite = overwrite;
+}
+
+void PdfToOffice::SetSaveToUserDir(bool saveToUserDir) {
+  m_IsSaveToUserDir = saveToUserDir;
+}
+
+void PdfToOffice::SetUserDir(const String& path) {
+  m_UserDir = path;
+}
+
+String PdfToOffice::SetOutPath() {
+  return m_OutPath;
+}
+
 void PdfToOffice::DoProgress(
     SolidFramework::ProgressEventArgsPtr pProgressEventArgs) {
   int progress = pProgressEventArgs->GetProgress();
@@ -64,30 +93,4 @@ void PdfToOffice::DoProgress(
 void PdfToOffice::SetSite(IProgressSite* progressSite) {
   s_ProgressSite = progressSite;
 }
-
-RES_CODE PdfToOffice::Convert(const String& /*path*/,
-                              const String& /*password*/) {
-  return RES_CODE::Unknown;
-}
-
-void PdfToOffice::Cancel() {
-  if (!m_Converter) {
-    return;
-  }
-  m_Converter->Cancel();
-  m_Converter->ClearSourceFiles();
-}
-
-void PdfToOffice::SetSaveToUserDir(bool saveToUserDir) {
-  m_IsSaveToUserDir = saveToUserDir;
-}
-
-void PdfToOffice::SetUserDir(const String& path) {
-  m_UserDir = path;
-}
-
-void PdfToOffice::SetOverwrite(bool overwrite) {
-  m_IsOverwrite = overwrite;
-}
-
 }  // namespace HpdfToOffice

--- a/PdfToOfficeLib/PdfToOffice.cpp
+++ b/PdfToOfficeLib/PdfToOffice.cpp
@@ -62,7 +62,7 @@ void PdfToOffice::SetUserDir(const String& path) {
   m_UserDir = path;
 }
 
-String PdfToOffice::SetOutPath() {
+String PdfToOffice::GetOutPath() {
   return m_OutPath;
 }
 

--- a/PdfToOfficeLib/PdfToOffice.h
+++ b/PdfToOfficeLib/PdfToOffice.h
@@ -27,7 +27,7 @@ class PdfToOffice : public IPdfToOffice {
   virtual void SetOverwrite(bool overwrite);
   virtual void SetSaveToUserDir(bool saveToUserDir);
   virtual void SetUserDir(const String& path);
-  virtual String SetOutPath();
+  virtual String GetOutPath();
 
  public:
   static void DoProgress(

--- a/PdfToOfficeLib/PdfToOffice.h
+++ b/PdfToOfficeLib/PdfToOffice.h
@@ -15,6 +15,7 @@ class PdfToOffice : public IPdfToOffice {
   bool m_IsOverwrite = false;
   bool m_IsSaveToUserDir = false;
   String m_UserDir;
+  String m_OutPath;
 
  public:
   PdfToOffice() = default;
@@ -26,6 +27,7 @@ class PdfToOffice : public IPdfToOffice {
   virtual void SetOverwrite(bool overwrite);
   virtual void SetSaveToUserDir(bool saveToUserDir);
   virtual void SetUserDir(const String& path);
+  virtual String SetOutPath();
 
  public:
   static void DoProgress(

--- a/PdfToOfficeLib/PdfToPptx.cpp
+++ b/PdfToOfficeLib/PdfToPptx.cpp
@@ -10,7 +10,9 @@ RES_CODE PdfToPptx::Convert(const String& path, const String& password) {
     outPath = m_UserDir + L"\\" + Util::Path::GetFileName(outPath);
   }
   outPath = Util::Path::ChangeExt(outPath, L".pptx");
-  outPath = Util::Path::GetAvailFileName(outPath);
+  if (!m_IsOverwrite)
+    outPath = Util::Path::GetAvailFileName(outPath);
+  m_OutPath = outPath;
 
   RES_CODE status = RES_CODE::Success;
   try {
@@ -25,7 +27,7 @@ RES_CODE PdfToPptx::Convert(const String& path, const String& password) {
     pConverter->SetOverwriteMode(
         SolidFramework::Plumbing::OverwriteMode::ForceOverwrite);
 
-    pConverter->ConvertTo(outPath, true);
+    pConverter->ConvertTo(outPath, m_IsOverwrite);
 
     status = static_cast<RES_CODE>(pConverter->GetResults()[0]->GetStatus());
 

--- a/PdfToOfficeLib/PdfToXlsx.cpp
+++ b/PdfToOfficeLib/PdfToXlsx.cpp
@@ -13,7 +13,9 @@ RES_CODE PdfToXlsx::Convert(const String& path, const String& password) {
     outPath = m_UserDir + L"\\" + Util::Path::GetFileName(outPath);
   }
   outPath = Util::Path::ChangeExt(outPath, L".xlsx");
-  outPath = Util::Path::GetAvailFileName(outPath);
+  if (!m_IsOverwrite)
+    outPath = Util::Path::GetAvailFileName(outPath);
+  m_OutPath = outPath;
 
   RES_CODE status = RES_CODE::Success;
   try {
@@ -31,7 +33,7 @@ RES_CODE PdfToXlsx::Convert(const String& path, const String& password) {
     pConverter->SetOutputType(
         SolidFramework::Converters::Plumbing::ExcelDocumentType::XlsX);
 
-    pConverter->ConvertTo(outPath, true);
+    pConverter->ConvertTo(outPath, m_IsOverwrite);
 
     status = static_cast<RES_CODE>(pConverter->GetResults()[0]->GetStatus());
 


### PR DESCRIPTION
변환 완료된 파일 더블클릭으로 열기

[내용]
- 창 최소 크기 지정
- 덮어쓰기 버그 수정
- 변환 완료 파일 더블클릭으로 열기
- 변환 완료 파일 Tooltip 경로 수정
- 파일 SelectionMode를 Extended로 수정
- 코드 정리

[영향]
- 창 최소 크기
- 덮어쓰기 기능
- 변환 완료된 파일 더블클릭으로 열기
- 변환 완료된 파일 Tooltip 메시지 원본 파일명에서 완료 파일명으로 수정
- 파일 여러개 선택 방식 변경 : 클릭하면 여러개 선택 가능->클릭으로는 한개의 파일, ctrl이나 shift로 여러개 선택