### PR TITLE
설정 및 정보 창 실행 위치 변경

### DIFF
--- a/PdfToOfficeApp/View/AboutWindow.xaml
+++ b/PdfToOfficeApp/View/AboutWindow.xaml
@@ -10,7 +10,8 @@
         d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
         ResizeMode="NoResize"
         Height="250"
-        Width="400">
+        Width="400"
+        WindowStartupLocation="CenterOwner">
 
   <Grid Margin="{StaticResource m-5}">
     <Grid.ColumnDefinitions>

--- a/PdfToOfficeApp/View/ConfigWindow.xaml
+++ b/PdfToOfficeApp/View/ConfigWindow.xaml
@@ -10,7 +10,8 @@
         d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
         ResizeMode="NoResize"
         Height="300"
-        Width="300">
+        Width="300"
+        WindowStartupLocation="CenterOwner">
 
   <Grid Margin="{StaticResource m-5}">
     <StackPanel>

--- a/PdfToOfficeApp/View/SelectFormatComp.xaml
+++ b/PdfToOfficeApp/View/SelectFormatComp.xaml
@@ -171,7 +171,8 @@
       </StackPanel>
     </Button>
 
-    <Button Grid.Column="3"
+    <Button Click="IDC_SelXlsx_Click"
+            Grid.Column="3"
             Margin="{StaticResource m-2}"
             Style="{StaticResource sf-radio}"
             ToolTip="{DynamicResource IDS_CONV_TYPE_XLSX}">


### PR DESCRIPTION
[내용]
- 설정/정보창 시작 위치를 메인창 중앙으로 고정
- 엑셀 그림 눌렀을 때 라디오버튼 체크 안되는 누락사항 수정

[영향]
- 설정창, 정보창 시작 위치
- 엑셀 그림으로 라디오 버튼 체크