### PR TITLE
#81 사용자는 Tooltip으로 파일 정보를 확인할 수 있다.

### DIFF
--- a/PdfToOfficeApp/MainWindow.xaml.cs
+++ b/PdfToOfficeApp/MainWindow.xaml.cs
@@ -225,7 +225,6 @@ namespace PdfToOfficeApp
                     if (doc.ResCode == RES_CODE.Success)
                     {
                         doc.ConvStatus = CONV_STATUS.COMPLETED;
-                        Util.StringManager.SetTooltipLang(doc);
                     }
                     else if (doc.ResCode == RES_CODE.Canceled || doc.ResCode == RES_CODE.CanceledExists)
                     {
@@ -234,7 +233,6 @@ namespace PdfToOfficeApp
                     else
                     {
                         doc.ConvStatus = CONV_STATUS.FAIL;
-                        Util.StringManager.SetTooltipLang(doc);
                     }
                 }
             }

--- a/PdfToOfficeApp/MainWindow.xaml.cs
+++ b/PdfToOfficeApp/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -224,7 +225,7 @@ namespace PdfToOfficeApp
                     if (doc.ResCode == RES_CODE.Success)
                     {
                         doc.ConvStatus = CONV_STATUS.COMPLETED;
-                        doc.Tooltip = doc.OutPath;
+                        Util.StringManager.SetTooltipLang(doc);
                     }
                     else if (doc.ResCode == RES_CODE.Canceled || doc.ResCode == RES_CODE.CanceledExists)
                     {
@@ -233,12 +234,7 @@ namespace PdfToOfficeApp
                     else
                     {
                         doc.ConvStatus = CONV_STATUS.FAIL;
-
-                        StringBuilder msg = new StringBuilder();
-                        msg.AppendLine(doc.FilePath);
-                        msg.AppendLine();
-                        msg.AppendFormat("⚠ {0}", Util.StringManager.GetMsg(doc.ResCode));
-                        doc.Tooltip = msg.ToString();
+                        Util.StringManager.SetTooltipLang(doc);
                     }
                 }
             }
@@ -378,7 +374,8 @@ namespace PdfToOfficeApp
 
             foreach (var file in fileNames)
             {
-                Doc doc = new Doc(file);
+                var info = new FileInfo(file);
+                Doc doc = new Doc(info);
                 GetModel().Docs.Add(doc);
             }
         }

--- a/PdfToOfficeApp/MainWindow.xaml.cs
+++ b/PdfToOfficeApp/MainWindow.xaml.cs
@@ -372,8 +372,10 @@ namespace PdfToOfficeApp
 
             foreach (var file in fileNames)
             {
-                var info = new FileInfo(file);
-                Doc doc = new Doc(info);
+                Doc doc = new Doc
+                {
+                    FilePath = file
+                };
                 GetModel().Docs.Add(doc);
             }
         }
@@ -419,9 +421,11 @@ namespace PdfToOfficeApp
 
         private void OnAbout(object sender, ExecutedRoutedEventArgs e)
         {
-            AboutWindow aboutWin = new AboutWindow();
-            aboutWin.Owner = this;
-            aboutWin.DataContext = GetModel();
+            AboutWindow aboutWin = new AboutWindow
+            {
+                Owner = this,
+                DataContext = GetModel()
+            };
             aboutWin.ShowDialog();
         }
 
@@ -432,9 +436,11 @@ namespace PdfToOfficeApp
 
         private void OnConfig(object sender, ExecutedRoutedEventArgs e)
         {
-            ConfigWindow confWin = new ConfigWindow();
-            confWin.Owner = this;
-            confWin.DataContext = GetModel();
+            ConfigWindow confWin = new ConfigWindow
+            {
+                Owner = this,
+                DataContext = GetModel()
+            };
             confWin.ShowDialog();
         }
 

--- a/PdfToOfficeApp/Misc/TooltipValueConverter.cs
+++ b/PdfToOfficeApp/Misc/TooltipValueConverter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows.Data;
+using PdfToOfficeAppModule;
 
 namespace PdfToOfficeApp
 {
@@ -10,46 +12,47 @@ namespace PdfToOfficeApp
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            // values[0] : doc.ConvStatus
-            // values[1] : doc.FilePath
-            // values[2] : doc.ResCode
-            // values[3] : doc.OutPath
-
-            FileInfo info;
-            StringBuilder msg = new StringBuilder();
             try
             {
-                if ((CONV_STATUS)values[0] == CONV_STATUS.FAIL)
+                var convStatus = (CONV_STATUS)values[0];
+                var filePath = (string)values[1];
+                var resCode = (RES_CODE)values[2];
+                var outPath = (string)values[3];
+
+                FileInfo info;
+                var msg = new StringBuilder();
+
+                switch (convStatus)
                 {
-                    msg.AppendLine(values[1].ToString());
-                    msg.AppendLine();
-                    msg.AppendFormat("⚠ {0}", Util.StringManager.GetMsg((PdfToOfficeAppModule.RES_CODE)values[2]));
+                    case CONV_STATUS.FAIL:
+                        msg.AppendLine(filePath);
+                        msg.AppendLine();
+                        msg.AppendFormat("⚠ {0}", Util.StringManager.GetMsg(resCode));
+                        break;
+                    case CONV_STATUS.COMPLETED:
+                        info = new FileInfo(outPath);
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), outPath);
+                        msg.AppendLine();
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
+                        msg.AppendLine();
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                        break;
+                    default:
+                        info = new FileInfo(filePath);
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), filePath);
+                        msg.AppendLine();
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
+                        msg.AppendLine();
+                        msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                        break;
                 }
-                else if ((CONV_STATUS)values[0] == CONV_STATUS.COMPLETED)
-                {
-                    info = new FileInfo(values[3].ToString());
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), values[3]);
-                    msg.AppendLine();
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
-                    msg.AppendLine();
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
-                }
-                else
-                {
-                    info = new FileInfo(values[1].ToString());
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), values[1]);
-                    msg.AppendLine();
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
-                    msg.AppendLine();
-                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
-                }
+                return msg.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.Assert(false, ex.Message);
                 return null;
             }
-
-            return msg.ToString();
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/PdfToOfficeApp/Misc/TooltipValueConverter.cs
+++ b/PdfToOfficeApp/Misc/TooltipValueConverter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Windows.Data;
+
+namespace PdfToOfficeApp
+{
+    public class TooltipValueConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            // values[0] : doc.ConvStatus
+            // values[1] : doc.FilePath
+            // values[2] : doc.ResCode
+            // values[3] : doc.OutPath
+
+            FileInfo info;
+            StringBuilder msg = new StringBuilder();
+            try
+            {
+                if ((CONV_STATUS)values[0] == CONV_STATUS.FAIL)
+                {
+                    msg.AppendLine(values[1].ToString());
+                    msg.AppendLine();
+                    msg.AppendFormat("⚠ {0}", Util.StringManager.GetMsg((PdfToOfficeAppModule.RES_CODE)values[2]));
+                }
+                else if ((CONV_STATUS)values[0] == CONV_STATUS.COMPLETED)
+                {
+                    info = new FileInfo(values[3].ToString());
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), values[3]);
+                    msg.AppendLine();
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
+                    msg.AppendLine();
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                }
+                else
+                {
+                    info = new FileInfo(values[1].ToString());
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), values[1]);
+                    msg.AppendLine();
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.BytesToString(info.Length));
+                    msg.AppendLine();
+                    msg.AppendFormat("{0} : {1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            return msg.ToString();
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/PdfToOfficeApp/Misc/Util.cs
+++ b/PdfToOfficeApp/Misc/Util.cs
@@ -177,7 +177,7 @@ namespace PdfToOfficeApp
                 return msg;
             }
 
-            public static string GetFileSize(long length)
+            public static string BytesToString(long length)
             {
                 try
                 {
@@ -208,37 +208,6 @@ namespace PdfToOfficeApp
                 {
                     return string.Empty;
                 }
-            }
-
-            public static void SetTooltipLang(Doc doc)
-            {
-                FileInfo info;
-                StringBuilder msg = new StringBuilder();
-                if (doc.ConvStatus == CONV_STATUS.FAIL)
-                {
-                    msg.AppendLine(doc.FilePath);
-                    msg.AppendLine();
-                    msg.AppendFormat("⚠ {0}", GetMsg(doc.ResCode));
-                }
-                else if (doc.ConvStatus == CONV_STATUS.COMPLETED)
-                {
-                    info = new FileInfo(doc.OutPath);
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_PATH"), doc.OutPath);
-                    msg.AppendLine();
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
-                    msg.AppendLine();
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
-                }
-                else
-                {
-                    info = new FileInfo(doc.FilePath);
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_PATH"), doc.FilePath);
-                    msg.AppendLine();
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
-                    msg.AppendLine();
-                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
-                }
-                doc.Tooltip = msg.ToString();
             }
         }
 

--- a/PdfToOfficeApp/Misc/Util.cs
+++ b/PdfToOfficeApp/Misc/Util.cs
@@ -176,6 +176,70 @@ namespace PdfToOfficeApp
 
                 return msg;
             }
+
+            public static string GetFileSize(long length)
+            {
+                try
+                {
+                    string strSize = "0Byte";
+                    double dSize = 0;
+                    if (length >= 8589900000)
+                    {
+                        dSize = length / (double)(1024 * 1024 * 1024);
+                        strSize = Math.Round(dSize, 3) + "GB";
+                    }
+                    else if (length >= 1048576)
+                    {
+                        dSize = length / (double)(1024 * 1024);
+                        strSize = Math.Round(dSize, 2) + "MB";
+                    }
+                    else if (length >= 1024)
+                    {
+                        dSize = length / (double)1024;
+                        strSize = Math.Round(dSize, 2) + "KB";
+                    }
+                    else
+                    {
+                        strSize = length + "byte";
+                    }
+                    return strSize;
+                }
+                catch (Exception)
+                {
+                    return string.Empty;
+                }
+            }
+
+            public static void SetTooltipLang(Doc doc)
+            {
+                FileInfo info;
+                StringBuilder msg = new StringBuilder();
+                if (doc.ConvStatus == CONV_STATUS.FAIL)
+                {
+                    msg.AppendLine(doc.FilePath);
+                    msg.AppendLine();
+                    msg.AppendFormat("⚠ {0}", GetMsg(doc.ResCode));
+                }
+                else if (doc.ConvStatus == CONV_STATUS.COMPLETED)
+                {
+                    info = new FileInfo(doc.OutPath);
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_PATH"), doc.OutPath);
+                    msg.AppendLine();
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
+                    msg.AppendLine();
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                }
+                else
+                {
+                    info = new FileInfo(doc.FilePath);
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_PATH"), doc.FilePath);
+                    msg.AppendLine();
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
+                    msg.AppendLine();
+                    msg.AppendFormat("{0}{1}", GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+                }
+                doc.Tooltip = msg.ToString();
+            }
         }
 
         public class PathManager

--- a/PdfToOfficeApp/PdfToOfficeApp.csproj
+++ b/PdfToOfficeApp/PdfToOfficeApp.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Misc\ProgressToAngleConverter.cs" />
     <Compile Include="Misc\DataConv.cs" />
     <Compile Include="Misc\ResConv.cs" />
+    <Compile Include="Misc\TooltipValueConverter.cs" />
     <Compile Include="ProgressSiteCli.cs" />
     <Compile Include="ViewModel\Doc.cs" />
     <Compile Include="ViewModel\DocList.cs" />

--- a/PdfToOfficeApp/Resources/Strings/en-US/pdftooffice_strings.xaml
+++ b/PdfToOfficeApp/Resources/Strings/en-US/pdftooffice_strings.xaml
@@ -41,7 +41,7 @@
   <System:String x:Key="IDS_PdfConverter_Convert">Being Converted File</System:String>    
   <System:String x:Key="IDS_ConvertUserCancelMessage">Converting to a document has been canceled.</System:String>
   <System:String x:Key="IDS_ConvertStopMessage">Please wait while stopping the operation.</System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">Size : </System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">Modified Time : </System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">Path : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">Size</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">Modified Time</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">Path</System:String>
 </ResourceDictionary>

--- a/PdfToOfficeApp/Resources/Strings/en-US/pdftooffice_strings.xaml
+++ b/PdfToOfficeApp/Resources/Strings/en-US/pdftooffice_strings.xaml
@@ -41,4 +41,7 @@
   <System:String x:Key="IDS_PdfConverter_Convert">Being Converted File</System:String>    
   <System:String x:Key="IDS_ConvertUserCancelMessage">Converting to a document has been canceled.</System:String>
   <System:String x:Key="IDS_ConvertStopMessage">Please wait while stopping the operation.</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">Size : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">Modified Time : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">Path : </System:String>
 </ResourceDictionary>

--- a/PdfToOfficeApp/Resources/Strings/ko-KR/pdftooffice_strings.xaml
+++ b/PdfToOfficeApp/Resources/Strings/ko-KR/pdftooffice_strings.xaml
@@ -40,4 +40,7 @@
   <System:String x:Key="IDS_HNC_PDFSDK_MSG_WARNING_NOTIFY_LIMIT">PDF를 편집 가능한 문서로 변환할 수 있으며, 변환 시 약간의 시간이 소요될 수 있습니다. &#xA;변환하는 동안 일부 속성이 변경되어 원본 PDF 파일과 내용이 달라질 수 있습니다. &#xA;대용량 문서는 최대 %d쪽까지 변환할 수 있습니다.</System:String>
   <System:String x:Key="IDS_ConvertUserCancelMessage">문서로 변환하기를 취소했습니다.</System:String>
   <System:String x:Key="IDS_ConvertStopMessage">작업을 중지하는 동안 잠시만 기다려 주세요.</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">크기 : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">수정한 날짜 : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">저장 위치 : </System:String>
 </ResourceDictionary>

--- a/PdfToOfficeApp/Resources/Strings/ko-KR/pdftooffice_strings.xaml
+++ b/PdfToOfficeApp/Resources/Strings/ko-KR/pdftooffice_strings.xaml
@@ -40,7 +40,7 @@
   <System:String x:Key="IDS_HNC_PDFSDK_MSG_WARNING_NOTIFY_LIMIT">PDF를 편집 가능한 문서로 변환할 수 있으며, 변환 시 약간의 시간이 소요될 수 있습니다. &#xA;변환하는 동안 일부 속성이 변경되어 원본 PDF 파일과 내용이 달라질 수 있습니다. &#xA;대용량 문서는 최대 %d쪽까지 변환할 수 있습니다.</System:String>
   <System:String x:Key="IDS_ConvertUserCancelMessage">문서로 변환하기를 취소했습니다.</System:String>
   <System:String x:Key="IDS_ConvertStopMessage">작업을 중지하는 동안 잠시만 기다려 주세요.</System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">크기 : </System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">수정한 날짜 : </System:String>
-  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">저장 위치 : </System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_SIZE">크기</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_WRITE_TIME">수정한 날짜</System:String>
+  <System:String x:Key="IDS_TOOLTIP_MSG_PATH">저장 위치</System:String>
 </ResourceDictionary>

--- a/PdfToOfficeApp/Resources/Themes/Generic.xaml
+++ b/PdfToOfficeApp/Resources/Themes/Generic.xaml
@@ -37,6 +37,7 @@
   <local:ProgressToAngleConverter x:Key="ProgressConverter" />
   <local:DataConv x:Key="dataConv" />
   <local:ResConv x:Key="resConv" />
+  <local:TooltipValueConverter x:Key="TooltipConverter" />
 
   <DrawingImage x:Key="drawing_validate_check"
                 Drawing="{DynamicResource dlg_data_validate_check}">

--- a/PdfToOfficeApp/View/DocListComp.xaml
+++ b/PdfToOfficeApp/View/DocListComp.xaml
@@ -186,12 +186,13 @@
         <Grid Width="{StaticResource sz-list-item}"
               Height="{StaticResource sz-list-item}">
           <Grid.ToolTip>
-            <MultiBinding Converter="{StaticResource TooltipConverter}"
-                          ConverterParameter="Doc">
+            <MultiBinding Converter="{StaticResource TooltipConverter}">
               <Binding Path="ConvStatus" />
               <Binding Path="FilePath" />
               <Binding Path="ResCode" />
               <Binding Path="OutPath" />
+              <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}"
+                       Path="DataContext.Lang" />
             </MultiBinding>
           </Grid.ToolTip>
           <Grid.RowDefinitions>

--- a/PdfToOfficeApp/View/DocListComp.xaml
+++ b/PdfToOfficeApp/View/DocListComp.xaml
@@ -184,8 +184,16 @@
 
       <DataTemplate x:Key="doclistbox-item">
         <Grid Width="{StaticResource sz-list-item}"
-              Height="{StaticResource sz-list-item}"
-              ToolTip="{Binding Path=Tooltip}">
+              Height="{StaticResource sz-list-item}">
+          <Grid.ToolTip>
+            <MultiBinding Converter="{StaticResource TooltipConverter}"
+                          ConverterParameter="Doc">
+              <Binding Path="ConvStatus" />
+              <Binding Path="FilePath" />
+              <Binding Path="ResCode" />
+              <Binding Path="OutPath" />
+            </MultiBinding>
+          </Grid.ToolTip>
           <Grid.RowDefinitions>
             <RowDefinition Height="2*" />
             <RowDefinition Height="*" />

--- a/PdfToOfficeApp/ViewModel/Doc.cs
+++ b/PdfToOfficeApp/ViewModel/Doc.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using PdfToOfficeAppModule;
 
 namespace PdfToOfficeApp
@@ -10,10 +11,16 @@ namespace PdfToOfficeApp
         {
         }
 
-        public Doc(string filePath)
+        public Doc(FileInfo info)
         {
-            FilePath = filePath;
-            Tooltip = filePath;
+            FilePath = info.FullName;
+            StringBuilder msg = new StringBuilder();
+            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), FilePath);
+            msg.AppendLine();
+            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
+            msg.AppendLine();
+            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
+            Tooltip = msg.ToString();
         }
 
         private string _FilePath = string.Empty;
@@ -110,6 +117,28 @@ namespace PdfToOfficeApp
             {
                 _OutPath = value;
                 OnPropertyChanged("OutPath");
+            }
+        }
+
+        private string _FileSize = string.Empty;
+        public string FileSize
+        {
+            get { return _FileSize; }
+            set
+            {
+                _FileSize = value;
+                OnPropertyChanged("FileSize");
+            }
+        }
+
+        private string _WriteTime = string.Empty;
+        public string WriteTime
+        {
+            get { return _WriteTime; }
+            set
+            {
+                _WriteTime = value;
+                OnPropertyChanged("WriteTime");
             }
         }
     }

--- a/PdfToOfficeApp/ViewModel/Doc.cs
+++ b/PdfToOfficeApp/ViewModel/Doc.cs
@@ -11,12 +11,6 @@ namespace PdfToOfficeApp
         {
         }
 
-        // TODO : 삭제 후 초기 툴팁 확인
-        public Doc(FileInfo info)
-        {
-            FilePath = info.FullName;
-        }
-
         private string _FilePath = string.Empty;
         public string FilePath
         {

--- a/PdfToOfficeApp/ViewModel/Doc.cs
+++ b/PdfToOfficeApp/ViewModel/Doc.cs
@@ -11,16 +11,10 @@ namespace PdfToOfficeApp
         {
         }
 
+        // TODO : 삭제 후 초기 툴팁 확인
         public Doc(FileInfo info)
         {
             FilePath = info.FullName;
-            StringBuilder msg = new StringBuilder();
-            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_PATH"), FilePath);
-            msg.AppendLine();
-            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_SIZE"), Util.StringManager.GetFileSize(info.Length));
-            msg.AppendLine();
-            msg.AppendFormat("{0}{1}", Util.StringManager.GetString("IDS_TOOLTIP_MSG_WRITE_TIME"), info.LastWriteTime);
-            Tooltip = msg.ToString();
         }
 
         private string _FilePath = string.Empty;

--- a/PdfToOfficeApp/ViewModel/MainViewModel.cs
+++ b/PdfToOfficeApp/ViewModel/MainViewModel.cs
@@ -216,6 +216,10 @@ namespace PdfToOfficeApp
                 Util.LangManager.Apply(value);
 
                 OnPropertyChanged("Lang");
+                foreach (Doc doc in Docs)
+                {
+                    Util.StringManager.SetTooltipLang(doc);
+                }
             }
         }
     }

--- a/PdfToOfficeApp/ViewModel/MainViewModel.cs
+++ b/PdfToOfficeApp/ViewModel/MainViewModel.cs
@@ -215,7 +215,6 @@ namespace PdfToOfficeApp
 
                 Util.LangManager.Apply(value);
 
-                // TODO : Lang 변경 확인하여 툴팁 언어 변경되도록
                 OnPropertyChanged("Lang");
             }
         }

--- a/PdfToOfficeApp/ViewModel/MainViewModel.cs
+++ b/PdfToOfficeApp/ViewModel/MainViewModel.cs
@@ -215,11 +215,8 @@ namespace PdfToOfficeApp
 
                 Util.LangManager.Apply(value);
 
+                // TODO : Lang 변경 확인하여 툴팁 언어 변경되도록
                 OnPropertyChanged("Lang");
-                foreach (Doc doc in Docs)
-                {
-                    Util.StringManager.SetTooltipLang(doc);
-                }
             }
         }
     }

--- a/PdfToOfficeUnitTest/PdfToOfficeUnitTest.cs
+++ b/PdfToOfficeUnitTest/PdfToOfficeUnitTest.cs
@@ -53,7 +53,9 @@ namespace PdfToOfficeUnitTest
 
             for (int i = 0; i < fileNames.Length; i++)
             {
-                var isExist = model.Docs.Any(e => (e.FilePath == fileNames[i]));
+                FileInfo fileInfo = new FileInfo(fileNames[i]);
+
+                var isExist = model.Docs.Any(e => (e.FilePath == fileInfo.FullName));
                 Assert.AreEqual(true, isExist);
             }
         }
@@ -64,7 +66,8 @@ namespace PdfToOfficeUnitTest
             bool canExecute = MainWindow.ConvertCommand.CanExecute(null, window);
             Assert.AreEqual(false, canExecute);
 
-            model.Docs.Add(new Doc(SAMPLE_PATH));
+            var info = new FileInfo(SAMPLE_PATH);
+            model.Docs.Add(new Doc(info));
             model.AppStatus = APP_STATUS.READY;
             model.ConvFileType = FILE_TYPE.DOCX;
 
@@ -83,7 +86,8 @@ namespace PdfToOfficeUnitTest
             bool canExecute = MainWindow.RemoveFileCommand.CanExecute(null, window);
             Assert.AreEqual(false, canExecute);
 
-            model.Docs.Add(new Doc(SAMPLE_PATH));
+            var info = new FileInfo(SAMPLE_PATH);
+            model.Docs.Add(new Doc(info));
             model.AppStatus = APP_STATUS.READY;
             model.SelectedItems = model.Docs;
 

--- a/PdfToOfficeUnitTest/PdfToOfficeUnitTest.cs
+++ b/PdfToOfficeUnitTest/PdfToOfficeUnitTest.cs
@@ -53,9 +53,7 @@ namespace PdfToOfficeUnitTest
 
             for (int i = 0; i < fileNames.Length; i++)
             {
-                FileInfo fileInfo = new FileInfo(fileNames[i]);
-
-                var isExist = model.Docs.Any(e => (e.FilePath == fileInfo.FullName));
+                var isExist = model.Docs.Any(e => (e.FilePath == fileNames[i]));
                 Assert.AreEqual(true, isExist);
             }
         }
@@ -66,8 +64,11 @@ namespace PdfToOfficeUnitTest
             bool canExecute = MainWindow.ConvertCommand.CanExecute(null, window);
             Assert.AreEqual(false, canExecute);
 
-            var info = new FileInfo(SAMPLE_PATH);
-            model.Docs.Add(new Doc(info));
+            Doc doc = new Doc
+            {
+                FilePath = SAMPLE_PATH
+            };
+            model.Docs.Add(doc);
             model.AppStatus = APP_STATUS.READY;
             model.ConvFileType = FILE_TYPE.DOCX;
 
@@ -86,8 +87,11 @@ namespace PdfToOfficeUnitTest
             bool canExecute = MainWindow.RemoveFileCommand.CanExecute(null, window);
             Assert.AreEqual(false, canExecute);
 
-            var info = new FileInfo(SAMPLE_PATH);
-            model.Docs.Add(new Doc(info));
+            Doc doc = new Doc
+            {
+                FilePath = SAMPLE_PATH
+            };
+            model.Docs.Add(doc);
             model.AppStatus = APP_STATUS.READY;
             model.SelectedItems = model.Docs;
 


### PR DESCRIPTION
[내용]
- 변환 전, 후, 실패 시 ToolTip 내용 변경 및 다국어 적용
- 파일 크기 byte, KB, MB, GB 로 변환하여 표기
- Doc 생성자 매개변수 변경
- 파일 추가 단위테스트 수정

[영향]
- 변환 전, 후, 실패 시 파일 ToolTip
- 언어 변경 시 파일 ToolTip